### PR TITLE
Feat/support client certficate publish

### DIFF
--- a/packages/agent-base/package.json
+++ b/packages/agent-base/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TooTallNate/proxy-agents.git",
+    "url": "https://github.com/yumemi-makiyama/proxy-agents.git",
     "directory": "packages/agent-base"
   },
   "keywords": [

--- a/packages/data-uri-to-buffer/package.json
+++ b/packages/data-uri-to-buffer/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TooTallNate/proxy-agents.git",
+    "url": "https://github.com/yumemi-makiyama/proxy-agents.git",
     "directory": "packages/data-uri-to-buffer"
   },
   "engines": {

--- a/packages/degenerator/package.json
+++ b/packages/degenerator/package.json
@@ -16,7 +16,7 @@
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/TooTallNate/proxy-agents.git",
+    "url": "https://github.com/yumemi-makiyama/proxy-agents.git",
     "directory": "packages/degenerator"
   },
   "engines": {

--- a/packages/get-uri/package.json
+++ b/packages/get-uri/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TooTallNate/proxy-agents.git",
+    "url": "https://github.com/yumemi-makiyama/proxy-agents.git",
     "directory": "packages/get-uri"
   },
   "keywords": [

--- a/packages/http-proxy-agent/package.json
+++ b/packages/http-proxy-agent/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TooTallNate/proxy-agents.git",
+    "url": "https://github.com/yumemi-makiyama/proxy-agents.git",
     "directory": "packages/http-proxy-agent"
   },
   "keywords": [

--- a/packages/https-proxy-agent/package.json
+++ b/packages/https-proxy-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "https-proxy-agent",
-  "version": "7.0.2",
+  "version": "7.1.0",
   "description": "An HTTP(s) proxy `http.Agent` implementation for HTTPS",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/https-proxy-agent/package.json
+++ b/packages/https-proxy-agent/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TooTallNate/proxy-agents.git",
+    "url": "https://github.com/yumemi-makiyama/proxy-agents.git",
     "directory": "packages/https-proxy-agent"
   },
   "keywords": [

--- a/packages/https-proxy-agent/src/index.ts
+++ b/packages/https-proxy-agent/src/index.ts
@@ -46,12 +46,15 @@ export class HttpsProxyAgent<Uri extends string> extends Agent {
 	readonly proxy: URL;
 	proxyHeaders: OutgoingHttpHeaders | (() => OutgoingHttpHeaders);
 	connectOpts: net.TcpNetConnectOpts & tls.ConnectionOptions;
+	forwardingOpts: HttpsProxyAgentOptions<string>;
 
-	constructor(proxy: Uri | URL, opts?: HttpsProxyAgentOptions<Uri>) {
+
+	constructor(proxy: Uri | URL, opts?: HttpsProxyAgentOptions<Uri>, forwardingOpts?: HttpsProxyAgentOptions<Uri>) {
 		super(opts);
 		this.options = { path: undefined };
 		this.proxy = typeof proxy === 'string' ? new URL(proxy) : proxy;
 		this.proxyHeaders = opts?.headers ?? {};
+		this.forwardingOpts = forwardingOpts ?? {};
 		debug('Creating new HttpsProxyAgent instance: %o', this.proxy.href);
 
 		// Trim off the brackets from IPv6 addresses
@@ -147,6 +150,7 @@ export class HttpsProxyAgent<Uri extends string> extends Agent {
 				const servername = opts.servername || opts.host;
 				return tls.connect({
 					...omit(opts, 'host', 'path', 'port'),
+					...this.forwardingOpts,
 					socket,
 					servername: net.isIP(servername) ? undefined : servername,
 				});

--- a/packages/pac-proxy-agent/package.json
+++ b/packages/pac-proxy-agent/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TooTallNate/proxy-agents.git",
+    "url": "https://github.com/yumemi-makiyama/proxy-agents.git",
     "directory": "packages/pac-proxy-agent"
   },
   "keywords": [

--- a/packages/pac-resolver/package.json
+++ b/packages/pac-resolver/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TooTallNate/proxy-agents.git",
+    "url": "https://github.com/yumemi-makiyama/proxy-agents.git",
     "directory": "packages/pac-resolver"
   },
   "engines": {

--- a/packages/proxy-agent/package.json
+++ b/packages/proxy-agent/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TooTallNate/proxy-agents.git",
+    "url": "https://github.com/yumemi-makiyama/proxy-agents.git",
     "directory": "packages/proxy-agent"
   },
   "keywords": [

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -29,7 +29,7 @@
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/TooTallNate/proxy-agents.git",
+    "url": "https://github.com/yumemi-makiyama/proxy-agents.git",
     "directory": "packages/proxy"
   },
   "license": "MIT",

--- a/packages/socks-proxy-agent/package.json
+++ b/packages/socks-proxy-agent/package.json
@@ -92,7 +92,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/TooTallNate/proxy-agents.git",
+    "url": "https://github.com/yumemi-makiyama/proxy-agents.git",
     "directory": "packages/socks-proxy-agent"
   },
   "keywords": [


### PR DESCRIPTION
https-proxy-agent が クライアント証明をサポートする